### PR TITLE
Add missing button variant types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,30 @@
-node_modules
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# bucklescript
+/lib
+/types
 .merlin
-lib
+*.bs.js
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE
 .idea
-yarn-error.log
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/src/MaterialUi_Button.re
+++ b/src/MaterialUi_Button.re
@@ -15,8 +15,10 @@ type size = [
 
 [@bs.deriving jsConverter]
 type variant = [
+  | [@bs.as "text"] `Text
   | [@bs.as "flat"] `Flat
   | [@bs.as "outlined"] `Outlined
+  | [@bs.as "contained"] `Contained
   | [@bs.as "raised"] `Raised
   | [@bs.as "fab"] `Fab
 ];


### PR DESCRIPTION
Hi, thanks for your work to make the binding for `material-ui` 👍 
I am fairly new to Reason/OCaml, so I just try out some basic usage of button, I found out there is some mismatch between `variant` type and button API [doc](https://material-ui.com/api/button/#props).
So I try to add up these missing `variant`.