### PR TITLE
reverted README changes relating to ppx_withStyles install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ to add the library to your project dependencies. And add `@jsiebern/bs-material-
 
 ## Installation of the `withStyles` code extension (ppx)
 
-**Mac users:** Add the entry `./node_modules/@jsiebern/bs-material-ui/bin/ppx_withStyles-darwin-x64` to the `ppx-flags` node of your `bsconfig.json`.
-
-**Linux users:** Add the entry `./node_modules/@jsiebern/bs-material-ui/bin/ppx_withStyles-linux-x64` to the `ppx-flags` node of your `bsconfig.json`.
+Add the entry `./node_modules/@jsiebern/bs-material-ui/ppx_withStyles` to the `ppx-flags` node of your `bsconfig.json`.
 
 ## Example
 


### PR DESCRIPTION
This PR reverts the recent README changes since the `post-install` script makes them invalid.