### PR TITLE
update examples with latest reason syntax

### DIFF
--- a/examples/ExampleClassOverride.re
+++ b/examples/ExampleClassOverride.re
@@ -4,7 +4,7 @@ let component = ReasonReact.statelessComponent("Example");
   "OverrideExample"({
     fontSize: ReactDOMRe.Style.make(~fontSize="30px", ()),
     bgColor:
-      ReactDOMRe.Style.make(~backgroundColor=MaterialUi.Colors.Red.c300, ())
+      ReactDOMRe.Style.make(~backgroundColor=MaterialUi.Colors.Red.c300, ()),
   })
 ];
 
@@ -12,14 +12,14 @@ let make = _children => {
   ...component,
   render: _self =>
     <OverrideExample
-      render=(
+      render={
         classes =>
           <MaterialUi.Button
             color=`Primary
             variant=`Raised
             classes=[Root(classes.fontSize), RaisedPrimary(classes.bgColor)]>
-            (ReasonReact.stringToElement("Example Button"))
+            {ReasonReact.string("Example Button")}
           </MaterialUi.Button>
-      )
-    />
+      }
+    />,
 };

--- a/examples/ExampleList.re
+++ b/examples/ExampleList.re
@@ -10,10 +10,10 @@ let component = ReasonReact.statelessComponent("Example");
         ~overflow="auto",
         ~maxHeight="300px",
         ~backgroundColor="#FFFFFF",
-        ()
+        (),
       ),
     listSection: ReactDOMRe.Style.make(~backgroundColor="inherit", ()),
-    ul: ReactDOMRe.Style.make(~backgroundColor="inherit", ~padding="0", ())
+    ul: ReactDOMRe.Style.make(~backgroundColor="inherit", ~padding="0", ()),
   })
 ];
 
@@ -23,73 +23,73 @@ let make = _children => {
     let subheader = <li />;
     MaterialUi.(
       <ExampleStyles
-        render=(
+        render={
           classes =>
             <Card>
               <CardHeader
-                title=(ReasonReact.stringToElement("Example Title"))
-                subheader=(ReasonReact.stringToElement("A Subtitle"))
+                title={ReasonReact.string("Example Title")}
+                subheader={ReasonReact.string("A Subtitle")}
               />
               <CardContent>
-                <List className=classes.root subheader>
-                  (
-                    ReasonReact.arrayToElement(
+                <List className={classes.root} subheader>
+                  {
+                    ReasonReact.array(
                       [|0, 1, 2, 3, 4|]
                       |> Array.map(sectionId =>
                            <li
-                             key=("section-" ++ string_of_int(sectionId))
-                             className=classes.listSection>
-                             <ul className=classes.ul>
-                               (
-                                 ReasonReact.arrayToElement(
+                             key={"section-" ++ string_of_int(sectionId)}
+                             className={classes.listSection}>
+                             <ul className={classes.ul}>
+                               {
+                                 ReasonReact.array(
                                    Array.append(
                                      [|
                                        <ListSubheader key="header">
-                                         (
-                                           ReasonReact.stringToElement(
+                                         {
+                                           ReasonReact.string(
                                              "I'm sticky "
-                                             ++ string_of_int(sectionId)
+                                             ++ string_of_int(sectionId),
                                            )
-                                         )
-                                       </ListSubheader>
+                                         }
+                                       </ListSubheader>,
                                      |],
                                      [|0, 1, 2|]
                                      |> Array.map(item =>
                                           <ListItem
-                                            key=(
+                                            key={
                                               "item-"
                                               ++ string_of_int(sectionId)
                                               ++ "-"
                                               ++ string_of_int(item)
-                                            )>
+                                            }>
                                             <ListItemText
-                                              primary=(
-                                                ReasonReact.stringToElement(
+                                              primary={
+                                                ReasonReact.string(
                                                   "Item "
-                                                  ++ string_of_int(item)
+                                                  ++ string_of_int(item),
                                                 )
-                                              )
+                                              }
                                             />
                                           </ListItem>
-                                        )
-                                   )
+                                        ),
+                                   ),
                                  )
-                               )
+                               }
                              </ul>
                            </li>
-                         )
+                         ),
                     )
-                  )
+                  }
                 </List>
               </CardContent>
               <CardActions>
                 <Button color=`Primary variant=`Raised href="#/example/route">
-                  (ReasonReact.stringToElement("Go to example"))
+                  {ReasonReact.string("Go to example")}
                 </Button>
               </CardActions>
             </Card>
-        )
+        }
       />
     );
-  }
+  },
 };

--- a/examples/ExampleWithStylesSafe.re
+++ b/examples/ExampleWithStylesSafe.re
@@ -2,7 +2,7 @@ let component = ReasonReact.statelessComponent("Example");
 
 [%mui.withStyles
   "StyledExample"({
-    alignRight: ReactDOMRe.Style.make(~width="100%", ~textAlign="right", ())
+    alignRight: ReactDOMRe.Style.make(~width="100%", ~textAlign="right", ()),
   })
 ];
 
@@ -10,13 +10,11 @@ let make = _children => {
   ...component,
   render: _self =>
     <StyledExample
-      render=(
+      render={
         classes =>
-          <div className=classes.alignRight>
-            (
-              ReasonReact.stringToElement("Example text - aligned to the right")
-            )
+          <div className={classes.alignRight}>
+            {ReasonReact.string("Example text - aligned to the right")}
           </div>
-      )
-    />
+      }
+    />,
 };

--- a/examples/ExampleWithStylesUnsafe.re
+++ b/examples/ExampleWithStylesUnsafe.re
@@ -7,16 +7,15 @@ let make = _children => {
       classes=[
         {
           name: "alignRight",
-          styles: ReactDOMRe.Style.make(~width="100%", ~textAlign="right", ())
-        }
+          styles:
+            ReactDOMRe.Style.make(~width="100%", ~textAlign="right", ()),
+        },
       ]
-      render=(
+      render={
         classes =>
           <div className=classes##alignRight>
-            (
-              ReasonReact.stringToElement("Example text - aligned to the right")
-            )
+            {ReasonReact.string("Example text - aligned to the right")}
           </div>
-      )
-    />
+      }
+    />,
 };


### PR DESCRIPTION
I fixed the compilation errors in the examples.

I didn't know how to fix this deprecation warning though:

<img width="526" alt="screen shot 2018-10-10 at 22 26 49" src="https://user-images.githubusercontent.com/514563/46764737-94239a00-ccdd-11e8-921b-ce5185b3acda.png">

https://github.com/jsiebern/bs-material-ui/blob/4487146ba751fc2ce11919bfb11a2973b3904a4a/examples/ExamplePopover.re#L51

Any ideas @jsiebern?