### PR TITLE
Fix filename ref for case-sensitive filesystems

### DIFF
--- a/public/bs-material-ui-ppx/package.json
+++ b/public/bs-material-ui-ppx/package.json
@@ -11,8 +11,8 @@
     "author": "Jonathan Siebern <jsiebern88@gmail.com>",
     "license": "MIT",
     "scripts": {
-        "build": "bsb -make-world -backend native && cp ./lib/bs/native/ppx_withStyles.native ./ppx",
-        "postinstall": "bsb -make-world -backend native && cp ./lib/bs/native/ppx_withStyles.native ./ppx",
+        "build": "bsb -make-world -backend native && cp ./lib/bs/native/ppx_withstyles.native ./ppx",
+        "postinstall": "bsb -make-world -backend native && cp ./lib/bs/native/ppx_withstyles.native ./ppx",
         "clean": "bsb -clean-world",
         "watch": "bsb -make-world -backend native -w"
     },


### PR DESCRIPTION
This change looks like it got lost in the refactor

https://github.com/jsiebern/bs-material-ui/issues/40